### PR TITLE
fix: don't add important to generated utilities

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -219,12 +219,10 @@ module.exports = (input) => (options) => {
           [allColumnClasses.join(',\n')]: {
             position: 'relative',
             width: '100%',
-            ...getSpacing(gridGutterWidth, (spacing) => {
-              return {
-                paddingRight: spacing,
-                paddingLeft: spacing,
-              };
-            }),
+            ...getSpacing(gridGutterWidth, (spacing) => ({
+              paddingRight: spacing,
+              paddingLeft: spacing,
+            })),
           },
         },
         ...(hasResponsiveGridGutterWidths

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,30 +149,33 @@ module.exports = (input) => (options) => {
     // =============================================================================================
     // Row
     // =============================================================================================
-    addUtilities([
-      {
-        '.row': {
-          display: 'flex',
-          flexWrap: 'wrap',
-          ...getSpacing(gridGutterWidth, (spacing) => ({
-            marginLeft: `-${spacing}`,
-            marginRight: `-${spacing}`,
-          })),
+    addUtilities(
+      [
+        {
+          '.row': {
+            display: 'flex',
+            flexWrap: 'wrap',
+            ...getSpacing(gridGutterWidth, (spacing) => ({
+              marginLeft: `-${spacing}`,
+              marginRight: `-${spacing}`,
+            })),
+          },
         },
-      },
-      ...(hasResponsiveGridGutterWidths
-        ? screenKeys.map((name) => ({
-            [`@screen ${name}`]: {
-              '.row': {
-                ...getSpacing(gridGutterWidths[name], (spacing) => ({
-                  marginLeft: `-${spacing}`,
-                  marginRight: `-${spacing}`,
-                })),
+        ...(hasResponsiveGridGutterWidths
+          ? screenKeys.map((name) => ({
+              [`@screen ${name}`]: {
+                '.row': {
+                  ...getSpacing(gridGutterWidths[name], (spacing) => ({
+                    marginLeft: `-${spacing}`,
+                    marginRight: `-${spacing}`,
+                  })),
+                },
               },
-            },
-          }))
-        : []),
-    ]);
+            }))
+          : []),
+      ],
+      { respectImportant: false }
+    );
 
     if (generateNoGutters) {
       const allColSelector = `${[
@@ -216,10 +219,12 @@ module.exports = (input) => (options) => {
           [allColumnClasses.join(',\n')]: {
             position: 'relative',
             width: '100%',
-            ...getSpacing(gridGutterWidth, (spacing) => ({
-              paddingRight: spacing,
-              paddingLeft: spacing,
-            })),
+            ...getSpacing(gridGutterWidth, (spacing) => {
+              return {
+                paddingRight: spacing,
+                paddingLeft: spacing,
+              };
+            }),
           },
         },
         ...(hasResponsiveGridGutterWidths
@@ -235,7 +240,7 @@ module.exports = (input) => (options) => {
             }))
           : []),
       ],
-      { respectPrefix: false }
+      { respectPrefix: false, respectImportant: false }
     );
 
     addUtilities(
@@ -261,7 +266,7 @@ module.exports = (input) => (options) => {
           },
         })),
       ],
-      ['responsive']
+      { variants: ['responsive'], respectImportant: false }
     );
   }
 
@@ -279,7 +284,7 @@ module.exports = (input) => (options) => {
           [`.order-${size}`]: { order: `${size}` },
         })),
       ],
-      ['responsive']
+      { variants: ['responsive'], respectImportant: false }
     );
   }
 
@@ -301,7 +306,7 @@ module.exports = (input) => (options) => {
               };
         }),
       ],
-      ['responsive']
+      { variants: ['responsive'], respectImportant: false }
     );
   }
 };


### PR DESCRIPTION
This relates to (#71). When using `important: true` in the Tailwind config, all utilities have `!important` added to them. This was causing issues for us, because Bootstrap does not use `!important` for these classes.

