### PR TITLE
Disable warning if generateContainer option is false

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,7 @@ module.exports = plugin.withOptions((pluginOptions) => (options) => {
     ...pluginOptions,
   });
 
-  if (corePlugins('container')) {
+  if (generateContainer && corePlugins('container')) {
     console.warn(
       `⚠️  The ${pc.yellow(
         'container'


### PR DESCRIPTION
Just added a check for the `generateContainer` option so if its disabled there is no warning on build