### PR TITLE
feat: add container breakpoint, which is 100% until the specified breakpoint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,17 +65,25 @@ module.exports = plugin.withOptions((pluginOptions) => (options) => {
     // Container
     // =============================================================================================
     if (generateContainer) {
+      const containerProperties = {
+        width: setImportant('100%'),
+        marginRight: setImportant('auto'),
+        marginLeft: setImportant('auto'),
+        paddingRight: setImportant(`var(--bs-gutter-x, calc(${gridGutterWidth} / 2))`),
+        paddingLeft: setImportant(`var(--bs-gutter-x, calc(${gridGutterWidth} / 2))`),
+      };
+
       addComponents(
         [
           {
-            '.container, .container-fluid': {
-              width: setImportant('100%'),
-              marginRight: setImportant('auto'),
-              marginLeft: setImportant('auto'),
-              paddingRight: setImportant(`var(--bs-gutter-x, calc(${gridGutterWidth} / 2))`),
-              paddingLeft: setImportant(`var(--bs-gutter-x, calc(${gridGutterWidth} / 2))`),
-            },
+            '.container, .container-fluid': containerProperties,
           },
+          ...screenKeys.map((name) => ({
+            [`.container-${name}`]: {
+              ...containerProperties,
+              maxWidth: setImportant(containerMaxWidths[name] || screens[name]),
+            },
+          })),
           ...screenKeys.map((name) => ({
             [`@screen ${name}`]: {
               '.container': {

--- a/tests/__snapshots__/tailwind.grid-gutters.test.js.snap
+++ b/tests/__snapshots__/tailwind.grid-gutters.test.js.snap
@@ -9,6 +9,30 @@ exports[`should handle grid gutters 1`] = `
   padding-right: var(--bs-gutter-x, calc(1em / 2));
   padding-left: var(--bs-gutter-x, calc(1em / 2));
 }
+.container-mobile {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1em / 2));
+  padding-left: var(--bs-gutter-x, calc(1em / 2));
+  max-width: 60em;
+}
+.container-tablet {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1em / 2));
+  padding-left: var(--bs-gutter-x, calc(1em / 2));
+  max-width: 80em;
+}
+.container-desktop {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1em / 2));
+  padding-left: var(--bs-gutter-x, calc(1em / 2));
+  max-width: 120em;
+}
 @media (min-width: 60em) {
   .container {
     max-width: 60em;
@@ -160,6 +184,30 @@ exports[`should handle grid gutters 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1em / 2));
     padding-left: var(--bs-gutter-x, calc(1em / 2));
+  }
+  .mobile\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 60em;
+  }
+  .mobile\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 80em;
+  }
+  .mobile\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 120em;
   }
   @media (min-width: 60em) {
     .mobile\\\\:container {
@@ -362,6 +410,30 @@ exports[`should handle grid gutters 1`] = `
     padding-right: var(--bs-gutter-x, calc(1em / 2));
     padding-left: var(--bs-gutter-x, calc(1em / 2));
   }
+  .tablet\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 60em;
+  }
+  .tablet\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 80em;
+  }
+  .tablet\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 120em;
+  }
   @media (min-width: 60em) {
     .tablet\\\\:container {
       max-width: 60em;
@@ -562,6 +634,30 @@ exports[`should handle grid gutters 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1em / 2));
     padding-left: var(--bs-gutter-x, calc(1em / 2));
+  }
+  .desktop\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 60em;
+  }
+  .desktop\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 80em;
+  }
+  .desktop\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 120em;
   }
   @media (min-width: 60em) {
     .desktop\\\\:container {

--- a/tests/__snapshots__/tailwind.important.respect.test.js.snap
+++ b/tests/__snapshots__/tailwind.important.respect.test.js.snap
@@ -9,6 +9,30 @@ exports[`should handle defaults 1`] = `
   padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
   padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
 }
+.container-mobile {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 1em;
+}
+.container-tablet {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 2em;
+}
+.container-desktop {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 3em;
+}
 @media (min-width: 1em) {
   .container {
     max-width: 1em;
@@ -230,6 +254,30 @@ exports[`should handle defaults 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  }
+  .mobile\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1em;
+  }
+  .mobile\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 2em;
+  }
+  .mobile\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 3em;
   }
   @media (min-width: 1em) {
     .mobile\\\\:container {
@@ -462,6 +510,30 @@ exports[`should handle defaults 1`] = `
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
   }
+  .tablet\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1em;
+  }
+  .tablet\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 2em;
+  }
+  .tablet\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 3em;
+  }
   @media (min-width: 1em) {
     .tablet\\\\:container {
       max-width: 1em;
@@ -692,6 +764,30 @@ exports[`should handle defaults 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  }
+  .desktop\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1em;
+  }
+  .desktop\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 2em;
+  }
+  .desktop\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 3em;
   }
   @media (min-width: 1em) {
     .desktop\\\\:container {

--- a/tests/__snapshots__/tailwind.important.test.js.snap
+++ b/tests/__snapshots__/tailwind.important.test.js.snap
@@ -9,6 +9,30 @@ exports[`should handle defaults 1`] = `
   padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
   padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
 }
+.container-mobile {
+  width: 100% !important;
+  margin-right: auto !important;
+  margin-left: auto !important;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+  max-width: 1em !important;
+}
+.container-tablet {
+  width: 100% !important;
+  margin-right: auto !important;
+  margin-left: auto !important;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+  max-width: 2em !important;
+}
+.container-desktop {
+  width: 100% !important;
+  margin-right: auto !important;
+  margin-left: auto !important;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+  max-width: 3em !important;
+}
 @media (min-width: 1em) {
   .container {
     max-width: 1em !important;
@@ -230,6 +254,30 @@ exports[`should handle defaults 1`] = `
     margin-left: auto !important;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+  }
+  .mobile\\\\:container-mobile {
+    width: 100% !important;
+    margin-right: auto !important;
+    margin-left: auto !important;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    max-width: 1em !important;
+  }
+  .mobile\\\\:container-tablet {
+    width: 100% !important;
+    margin-right: auto !important;
+    margin-left: auto !important;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    max-width: 2em !important;
+  }
+  .mobile\\\\:container-desktop {
+    width: 100% !important;
+    margin-right: auto !important;
+    margin-left: auto !important;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    max-width: 3em !important;
   }
   @media (min-width: 1em) {
     .mobile\\\\:container {
@@ -462,6 +510,30 @@ exports[`should handle defaults 1`] = `
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
   }
+  .tablet\\\\:container-mobile {
+    width: 100% !important;
+    margin-right: auto !important;
+    margin-left: auto !important;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    max-width: 1em !important;
+  }
+  .tablet\\\\:container-tablet {
+    width: 100% !important;
+    margin-right: auto !important;
+    margin-left: auto !important;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    max-width: 2em !important;
+  }
+  .tablet\\\\:container-desktop {
+    width: 100% !important;
+    margin-right: auto !important;
+    margin-left: auto !important;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    max-width: 3em !important;
+  }
   @media (min-width: 1em) {
     .tablet\\\\:container {
       max-width: 1em !important;
@@ -692,6 +764,30 @@ exports[`should handle defaults 1`] = `
     margin-left: auto !important;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+  }
+  .desktop\\\\:container-mobile {
+    width: 100% !important;
+    margin-right: auto !important;
+    margin-left: auto !important;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    max-width: 1em !important;
+  }
+  .desktop\\\\:container-tablet {
+    width: 100% !important;
+    margin-right: auto !important;
+    margin-left: auto !important;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    max-width: 2em !important;
+  }
+  .desktop\\\\:container-desktop {
+    width: 100% !important;
+    margin-right: auto !important;
+    margin-left: auto !important;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2)) !important;
+    max-width: 3em !important;
   }
   @media (min-width: 1em) {
     .desktop\\\\:container {

--- a/tests/__snapshots__/tailwind.prefix-separator.test.js.snap
+++ b/tests/__snapshots__/tailwind.prefix-separator.test.js.snap
@@ -9,6 +9,30 @@ exports[`should handle custom prefix and separator 1`] = `
   padding-right: var(--bs-gutter-x, calc(1em / 2));
   padding-left: var(--bs-gutter-x, calc(1em / 2));
 }
+.PF-container-mobile {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1em / 2));
+  padding-left: var(--bs-gutter-x, calc(1em / 2));
+  max-width: 20em;
+}
+.PF-container-tablet {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1em / 2));
+  padding-left: var(--bs-gutter-x, calc(1em / 2));
+  max-width: 40em;
+}
+.PF-container-desktop {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1em / 2));
+  padding-left: var(--bs-gutter-x, calc(1em / 2));
+  max-width: 60em;
+}
 @media (min-width: 60em) {
   .PF-container {
     max-width: 20em;
@@ -120,6 +144,30 @@ exports[`should handle custom prefix and separator 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1em / 2));
     padding-left: var(--bs-gutter-x, calc(1em / 2));
+  }
+  .mobile_SP_PF-container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 20em;
+  }
+  .mobile_SP_PF-container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 40em;
+  }
+  .mobile_SP_PF-container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 60em;
   }
   @media (min-width: 60em) {
     .mobile_SP_PF-container {
@@ -242,6 +290,30 @@ exports[`should handle custom prefix and separator 1`] = `
     padding-right: var(--bs-gutter-x, calc(1em / 2));
     padding-left: var(--bs-gutter-x, calc(1em / 2));
   }
+  .tablet_SP_PF-container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 20em;
+  }
+  .tablet_SP_PF-container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 40em;
+  }
+  .tablet_SP_PF-container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 60em;
+  }
   @media (min-width: 60em) {
     .tablet_SP_PF-container {
       max-width: 20em;
@@ -362,6 +434,30 @@ exports[`should handle custom prefix and separator 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1em / 2));
     padding-left: var(--bs-gutter-x, calc(1em / 2));
+  }
+  .desktop_SP_PF-container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 20em;
+  }
+  .desktop_SP_PF-container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 40em;
+  }
+  .desktop_SP_PF-container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1em / 2));
+    padding-left: var(--bs-gutter-x, calc(1em / 2));
+    max-width: 60em;
   }
   @media (min-width: 60em) {
     .desktop_SP_PF-container {

--- a/tests/__snapshots__/tailwind.responsive-max-widths.test.js.snap
+++ b/tests/__snapshots__/tailwind.responsive-max-widths.test.js.snap
@@ -9,6 +9,30 @@ exports[`should handle responsive max widths 1`] = `
   padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
   padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
 }
+.container-mobile {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 20em;
+}
+.container-tablet {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 40em;
+}
+.container-desktop {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 60em;
+}
 @media (min-width: 60em) {
   .container {
     max-width: 20em;
@@ -120,6 +144,30 @@ exports[`should handle responsive max widths 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  }
+  .mobile\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 20em;
+  }
+  .mobile\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 40em;
+  }
+  .mobile\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 60em;
   }
   @media (min-width: 60em) {
     .mobile\\\\:container {
@@ -242,6 +290,30 @@ exports[`should handle responsive max widths 1`] = `
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
   }
+  .tablet\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 20em;
+  }
+  .tablet\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 40em;
+  }
+  .tablet\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 60em;
+  }
   @media (min-width: 60em) {
     .tablet\\\\:container {
       max-width: 20em;
@@ -362,6 +434,30 @@ exports[`should handle responsive max widths 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  }
+  .desktop\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 20em;
+  }
+  .desktop\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 40em;
+  }
+  .desktop\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 60em;
   }
   @media (min-width: 60em) {
     .desktop\\\\:container {

--- a/tests/__snapshots__/tailwind.rtl-prefix-separator.test.js.snap
+++ b/tests/__snapshots__/tailwind.rtl-prefix-separator.test.js.snap
@@ -9,6 +9,38 @@ exports[`should handle rtl option and custom prefix, separator 1`] = `
   padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
   padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
 }
+.PF-container-sm {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 540px;
+}
+.PF-container-md {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 720px;
+}
+.PF-container-lg {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 960px;
+}
+.PF-container-xl {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 1140px;
+}
 @media (min-width: 640px) {
   .PF-container {
     max-width: 540px;
@@ -134,6 +166,38 @@ exports[`should handle rtl option and custom prefix, separator 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  }
+  .sm_SP_PF-container-sm {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 540px;
+  }
+  .sm_SP_PF-container-md {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 720px;
+  }
+  .sm_SP_PF-container-lg {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 960px;
+  }
+  .sm_SP_PF-container-xl {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1140px;
   }
   @media (min-width: 640px) {
     .sm_SP_PF-container {
@@ -270,6 +334,38 @@ exports[`should handle rtl option and custom prefix, separator 1`] = `
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
   }
+  .md_SP_PF-container-sm {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 540px;
+  }
+  .md_SP_PF-container-md {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 720px;
+  }
+  .md_SP_PF-container-lg {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 960px;
+  }
+  .md_SP_PF-container-xl {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1140px;
+  }
   @media (min-width: 640px) {
     .md_SP_PF-container {
       max-width: 540px;
@@ -405,6 +501,38 @@ exports[`should handle rtl option and custom prefix, separator 1`] = `
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
   }
+  .lg_SP_PF-container-sm {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 540px;
+  }
+  .lg_SP_PF-container-md {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 720px;
+  }
+  .lg_SP_PF-container-lg {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 960px;
+  }
+  .lg_SP_PF-container-xl {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1140px;
+  }
   @media (min-width: 640px) {
     .lg_SP_PF-container {
       max-width: 540px;
@@ -539,6 +667,38 @@ exports[`should handle rtl option and custom prefix, separator 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  }
+  .xl_SP_PF-container-sm {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 540px;
+  }
+  .xl_SP_PF-container-md {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 720px;
+  }
+  .xl_SP_PF-container-lg {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 960px;
+  }
+  .xl_SP_PF-container-xl {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1140px;
   }
   @media (min-width: 640px) {
     .xl_SP_PF-container {

--- a/tests/__snapshots__/tailwind.rtl.test.js.snap
+++ b/tests/__snapshots__/tailwind.rtl.test.js.snap
@@ -9,6 +9,22 @@ exports[`should handle rtl 1`] = `
   padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
   padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
 }
+.container-mobile {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 1em;
+}
+.container-desktop {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 2em;
+}
 @media (min-width: 1em) {
   .container {
     max-width: 1em;
@@ -124,6 +140,22 @@ exports[`should handle rtl 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  }
+  .mobile\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1em;
+  }
+  .mobile\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 2em;
   }
   @media (min-width: 1em) {
     .mobile\\\\:container {
@@ -249,6 +281,22 @@ exports[`should handle rtl 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  }
+  .desktop\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1em;
+  }
+  .desktop\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 2em;
   }
   @media (min-width: 1em) {
     .desktop\\\\:container {

--- a/tests/__snapshots__/tailwind.test.js.snap
+++ b/tests/__snapshots__/tailwind.test.js.snap
@@ -9,6 +9,30 @@ exports[`should handle defaults 1`] = `
   padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
   padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
 }
+.container-mobile {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 1em;
+}
+.container-tablet {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 2em;
+}
+.container-desktop {
+  width: 100%;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+  padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  max-width: 3em;
+}
 @media (min-width: 1em) {
   .container {
     max-width: 1em;
@@ -230,6 +254,30 @@ exports[`should handle defaults 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  }
+  .mobile\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1em;
+  }
+  .mobile\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 2em;
+  }
+  .mobile\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 3em;
   }
   @media (min-width: 1em) {
     .mobile\\\\:container {
@@ -462,6 +510,30 @@ exports[`should handle defaults 1`] = `
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
   }
+  .tablet\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1em;
+  }
+  .tablet\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 2em;
+  }
+  .tablet\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 3em;
+  }
   @media (min-width: 1em) {
     .tablet\\\\:container {
       max-width: 1em;
@@ -692,6 +764,30 @@ exports[`should handle defaults 1`] = `
     margin-left: auto;
     padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
     padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+  }
+  .desktop\\\\:container-mobile {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 1em;
+  }
+  .desktop\\\\:container-tablet {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 2em;
+  }
+  .desktop\\\\:container-desktop {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: var(--bs-gutter-x, calc(1.5rem / 2));
+    padding-left: var(--bs-gutter-x, calc(1.5rem / 2));
+    max-width: 3em;
   }
   @media (min-width: 1em) {
     .desktop\\\\:container {


### PR DESCRIPTION
> Bootstrap comes with three different containers:
>
> .container, which sets a max-width at each responsive breakpoint
> .container-{breakpoint}, which is width: 100% until the specified breakpoint
> .container-fluid, which is width: 100% at all breakpoints

Extra small<576px | Small≥576px | Medium≥768px | Large≥992px | X-Large≥1200px | XX-Large≥1400px
-- | -- | -- | -- | -- | --
.container | 100% | 540px | 720px | 960px | 1140px | 1320px
.container-sm | 100% | 540px | 720px | 960px | 1140px | 1320px
.container-md | 100% | 100% | 720px | 960px | 1140px | 1320px
.container-lg | 100% | 100% | 100% | 960px | 1140px | 1320px
.container-xl | 100% | 100% | 100% | 100% | 1140px | 1320px
.container-xxl | 100% | 100% | 100% | 100% | 100% | 1320px
.container-fluid | 100% | 100% | 100% | 100% | 100% | 100%


https://getbootstrap.com/docs/5.2/layout/containers/#how-they-work